### PR TITLE
Entry & texture names allow '+' character

### DIFF
--- a/src/main/java/net/mtrop/doom/util/NameUtils.java
+++ b/src/main/java/net/mtrop/doom/util/NameUtils.java
@@ -19,9 +19,9 @@ import java.util.regex.Pattern;
 public final class NameUtils
 {
 	/** A regex pattern that matches valid entry names. */
-	public static final Pattern ENTRY_NAME = Pattern.compile("[A-Z0-9\\[\\]\\-\\_\\^\\\\]{1,8}");
+	public static final Pattern ENTRY_NAME = Pattern.compile("[A-Z0-9\\[\\]\\-\\_\\^+\\\\]{1,8}");
 	/** A regex pattern that matches valid texture names. */
-	public static final Pattern TEXTURE_NAME = Pattern.compile("(\\-|[A-Z0-9\\-\\_]{1,8})");
+	public static final Pattern TEXTURE_NAME = Pattern.compile("(\\-|[A-Z0-9\\-\\_+]{1,8})");
 
 	/** The name of the "blank" texture. */
 	public static final String EMPTY_TEXTURE_NAME = "-";

--- a/src/test/java/net/mtrop/doom/test/TestSuite.java
+++ b/src/test/java/net/mtrop/doom/test/TestSuite.java
@@ -10,10 +10,12 @@ package net.mtrop.doom.test;
 import net.mtrop.doom.PK3Test;
 import net.mtrop.doom.WadTest;
 import net.mtrop.doom.test.TestUtils.TestDependsOn;
+import net.mtrop.doom.util.NameUtilsTest;
 
 @TestDependsOn({
 	WadTest.class,
 	PK3Test.class,
+	NameUtilsTest.class,
 })
 public final class TestSuite
 {

--- a/src/test/java/net/mtrop/doom/util/NameUtilsTest.java
+++ b/src/test/java/net/mtrop/doom/util/NameUtilsTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2022 Matt Tropiano
+ * This program and the accompanying materials are made available under the 
+ * terms of the GNU Lesser Public License v2.1 which accompanies this 
+ * distribution, and is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ ******************************************************************************/
+package net.mtrop.doom.util;
+
+import static net.mtrop.doom.test.TestUtils.assertEqual;
+
+import net.mtrop.doom.test.TestUtils.Test;
+import net.mtrop.doom.util.NameUtils;
+
+public final class NameUtilsTest
+{
+	@Test
+	public void isValidEntryName() throws Exception
+	{
+		assertEqual(NameUtils.isValidEntryName("-"), true);
+		assertEqual(NameUtils.isValidEntryName("WALL00_3"), true);
+		assertEqual(NameUtils.isValidEntryName("SFALL1"), true);
+		assertEqual(NameUtils.isValidEntryName("_SFALL1"), true);
+		assertEqual(NameUtils.isValidEntryName("SFALL[1]"), true);
+		assertEqual(NameUtils.isValidEntryName("^SFALL1"), true);
+		assertEqual(NameUtils.isValidEntryName("METAL-2"), true);
+		assertEqual(NameUtils.isValidEntryName("--------"), true);
+		assertEqual(NameUtils.isValidEntryName("\\MARKER"), true);
+		assertEqual(NameUtils.isValidEntryName("\\\\MARKER"), true);
+		assertEqual(NameUtils.isValidEntryName("O2V+35_0"), true);
+		assertEqual(NameUtils.isValidEntryName("12345678"), true);
+
+		assertEqual(NameUtils.isValidEntryName("123456789"), false);
+		assertEqual(NameUtils.isValidEntryName("wall00_3"), false);
+		assertEqual(NameUtils.isValidEntryName(" "), false);
+		assertEqual(NameUtils.isValidEntryName(""), false);
+		assertEqual(NameUtils.isValidEntryName("NOUMLÄUT"), false);
+	}
+
+	@Test
+	public void isValidTextureName() throws Exception
+	{
+		assertEqual(NameUtils.isValidTextureName("-"), true);
+		assertEqual(NameUtils.isValidTextureName("AASTINKY"), true);
+		assertEqual(NameUtils.isValidTextureName("SFALL1"), true);
+		assertEqual(NameUtils.isValidTextureName("_SFALL1"), true);
+		assertEqual(NameUtils.isValidTextureName("METAL-2"), true);
+		assertEqual(NameUtils.isValidTextureName("--------"), true);
+		assertEqual(NameUtils.isValidTextureName("O2V+35_0"), true);
+		assertEqual(NameUtils.isValidTextureName("12345678"), true);
+
+		assertEqual(NameUtils.isValidTextureName("123456789"), false);
+		assertEqual(NameUtils.isValidTextureName("sfall1"), false);
+		assertEqual(NameUtils.isValidTextureName("SFALL[1]"), false);
+		assertEqual(NameUtils.isValidTextureName("^SFALL1"), false);
+		assertEqual(NameUtils.isValidTextureName("\\MARKER"), false);
+		assertEqual(NameUtils.isValidTextureName(" "), false);
+		assertEqual(NameUtils.isValidTextureName(""), false);
+		assertEqual(NameUtils.isValidTextureName("NOUMLÄUT"), false);
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/MTrop/DoomStruct/issues/11
Related https://github.com/MTrop/DoomStruct/issues/8

e.g., OTEX_1_1.wad contains a plus character in one of its patch lump names:

![otex-plus](https://user-images.githubusercontent.com/823566/161811638-06aaea32-504d-4159-b584-d94bb81a8f6a.png)

Texture names may also contain such a character. Example WAD that successfully loads in Chocolate Doom: [texture-entry-plus-char-test.zip](https://github.com/MTrop/DoomStruct/files/8420418/texture-entry-plus-char-test.zip)

I've also added some unit tests.

> Regex `NameUtils.ENTRY_NAME` may contain some extra `\\` escape characters in the character range? AFAIK `_` wouldn't need to be escaped.